### PR TITLE
dev-lang/tauthon: Fix ebuild

### DIFF
--- a/dev-lang/tauthon/tauthon-2.8.2.ebuild
+++ b/dev-lang/tauthon/tauthon-2.8.2.ebuild
@@ -337,6 +337,7 @@ src_install() {
 	# for python-exec
 	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
 
+	local -x EPYTHON=tauthon${SLOT}
 	# if not using a cross-compiler, use the fresh binary
 	if ! tc-is-cross-compiler; then
 		local -x PYTHON=./tauthon
@@ -345,7 +346,6 @@ src_install() {
 		vars=( PYTHON "${vars[@]}" )
 	fi
 
-	python_export "tauthon${SLOT}" "${vars[@]}"
 	echo "EPYTHON='${EPYTHON}'" > epython.py || die
 	python_domodule epython.py
 


### PR DESCRIPTION
python_export() is no longer usable due to eclass changes.

Resolves #65