### PR TITLE
app-emulation/vmware-workstation: Fix executable permissions

### DIFF
--- a/app-emulation/vmware-workstation/vmware-workstation-16.2.0.18760230-r1.ebuild
+++ b/app-emulation/vmware-workstation/vmware-workstation-16.2.0.18760230-r1.ebuild
@@ -281,7 +281,7 @@ src_install() {
 	dosym "${VM_INSTALL_DIR}"/lib/vmware/icu /etc/vmware/icu
 
 	# fix permissions
-	fperms 0755 "${VM_INSTALL_DIR}"/lib/vmware/bin/{appLoader,fusermount,mkisofs,vmware-remotemks}
+	fperms 0755 "${VM_INSTALL_DIR}"/lib/vmware/bin/*
 	fperms 0755 "${VM_INSTALL_DIR}"/lib/vmware/setup/vmware-config
 	fperms 4711 "${VM_INSTALL_DIR}"/lib/vmware/bin/vmware-vmx{,-debug,-stats}
 	fperms 0755 "${VM_INSTALL_DIR}"/lib/vmware/lib/libvmware-gksu.so/gksu-run-helper


### PR DESCRIPTION
Workstation 16.2 introduced new mksSandbox* executables. They are used
to create the 3D renderer. They are installed without executable
permissions though, breaking 3D acceleration with vmware giving an error
message when trying to enable it.

There's a couple other new executables in the bin directory as well:

  emmett, tpm2emu, vmrest

I don't know what these do, but it's clear that they should have
executable permissions. They are all reported as "ELF 64-bit [pie] LSB
executable" by the file tool. Especially "tpm2emu" sounds important for
Windows 11 TPM emulation. The others lacking exec perms probably result
in some breakages in things people haven't used or tested yet.

Instead of micro-managing every single executable name, just apply exec
permissions to every file in lib/vmware/bin/ to avoid future breakages
when upstream adds more executables. If a file in the bin/ directory, it
clearly is intended to be an executable. If upstream ever puts some
file in there that isn't supposed to be executable, it should still be
fine. Having exec perms on data files usually doesn't harm anything.