### PR TITLE
Adding x11-libs/libXinerama to RDEPEND

### DIFF
--- a/app-emulation/vmware-workstation/vmware-workstation-16.2.1.18811642-r1.ebuild
+++ b/app-emulation/vmware-workstation/vmware-workstation-16.2.1.18811642-r1.ebuild
@@ -75,6 +75,7 @@ RDEPEND="
 	x11-libs/startup-notification
 	x11-libs/xcb-util
 	x11-themes/hicolor-icon-theme
+	x11-libs/libXinerama
 	!app-emulation/vmware-player
 	!app-emulation/vmware-tools
 "


### PR DESCRIPTION
I add x11-libs/libXinerama to RDEPEND parameter, to avoid issues to change state of virtual machines by the abscence of this library.