### PR TITLE
app-emulation/vmware-modules: update to EAPI 8 and linux-mod-r1

### DIFF
--- a/acct-group/vmware/vmware-0.ebuild
+++ b/acct-group/vmware/vmware-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-group
+
+DESCRIPTION="Group for VMware"
+ACCT_GROUP_ID="-1"

--- a/app-emulation/vmware-modules/vmware-modules-16.2.5-r11.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-16.2.5-r11.ebuild
@@ -27,6 +27,10 @@ KEYWORDS="~amd64"
 
 RESTRICT="mirror"
 
+RDEPEND="
+	acct-group/vmware
+"
+
 S="${WORKDIR}/vmware-host-modules-${MY_COMMIT}"
 
 PATCHES=(

--- a/app-emulation/vmware-modules/vmware-modules-16.2.5-r11.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-16.2.5-r11.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit flag-o-matic linux-mod user udev
+inherit flag-o-matic linux-mod-r1 udev
 
 DESCRIPTION="VMware kernel modules"
 HOMEPAGE="https://github.com/mkubecek/vmware-host-modules"
@@ -45,7 +45,7 @@ pkg_setup() {
 	CONFIG_CHECK="${CONFIG_CHECK} VMWARE_VMCI ~VMWARE_VMCI_VSOCKETS"
 
 	linux-info_pkg_setup
-	linux-mod_pkg_setup
+	linux-mod-r1_pkg_setup
 
 	if kernel_is gt ${MY_KERNEL_VERSION//./ }; then
 		ewarn
@@ -53,22 +53,14 @@ pkg_setup() {
 		ewarn
 	fi
 
-	VMWARE_GROUP=${VMWARE_GROUP:-vmware}
-
 	VMWARE_MODULE_LIST="vmmon vmnet"
 
 	VMWARE_MOD_DIR="${PN}-${PVR}"
 
 	BUILD_TARGETS="auto-build KERNEL_DIR=${KERNEL_DIR} KBUILD_OUTPUT=${KV_OUT_DIR}"
 
-	enewgroup "${VMWARE_GROUP}"
-
 	filter-flags -mfpmath=sse -mavx -mpclmul -maes
 	append-cflags -mno-sse  # Found a problem similar to bug #492964
-
-	for mod in ${VMWARE_MODULE_LIST}; do
-		MODULE_NAMES="${MODULE_NAMES} ${mod}(misc:${S}/${mod}-only)"
-	done
 }
 
 src_prepare() {
@@ -82,8 +74,16 @@ src_prepare() {
 	default
 }
 
+src_compile() {
+	for mod in ${VMWARE_MODULE_LIST}; do
+		local modlist+=( ${mod}=misc:${S}/${mod}-only )
+	done
+
+	linux-mod-r1_src_compile
+}
+
 src_install() {
-	linux-mod_src_install
+	linux-mod-r1_src_install
 	local udevrules="${T}/60-vmware.rules"
 	cat > "${udevrules}" <<-EOF
 		KERNEL=="vmci",  GROUP="vmware", MODE="660"
@@ -111,12 +111,12 @@ src_install() {
 }
 
 pkg_postinst() {
-	linux-mod_pkg_postinst
+	linux-mod-r1_pkg_postinst
 	udev_reload
 	ewarn "Don't forget to run '/etc/init.d/vmware restart' to use the new kernel modules."
 }
 
 pkg_postrm() {
-	linux-mod_pkg_postrm
+	linux-mod-r1_pkg_postrm
 	udev_reload
 }

--- a/app-emulation/vmware-modules/vmware-modules-17.5.0-r3.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-17.5.0-r3.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit flag-o-matic linux-mod user udev
+inherit flag-o-matic linux-mod-r1 udev
 
 DESCRIPTION="VMware kernel modules"
 HOMEPAGE="https://github.com/mkubecek/vmware-host-modules"
@@ -40,7 +40,7 @@ pkg_setup() {
 	CONFIG_CHECK="${CONFIG_CHECK} VMWARE_VMCI ~VMWARE_VMCI_VSOCKETS"
 
 	linux-info_pkg_setup
-	linux-mod_pkg_setup
+	linux-mod-r1_pkg_setup
 
 	if kernel_is gt ${MY_KERNEL_VERSION//./ }; then
 		ewarn
@@ -48,22 +48,14 @@ pkg_setup() {
 		ewarn
 	fi
 
-	VMWARE_GROUP=${VMWARE_GROUP:-vmware}
-
 	VMWARE_MODULE_LIST="vmmon vmnet"
 
 	VMWARE_MOD_DIR="${PN}-${PVR}"
 
 	BUILD_TARGETS="auto-build KERNEL_DIR=${KERNEL_DIR} KBUILD_OUTPUT=${KV_OUT_DIR}"
 
-	enewgroup "${VMWARE_GROUP}"
-
 	filter-flags -mfpmath=sse -mavx -mpclmul -maes
 	append-cflags -mno-sse  # Found a problem similar to bug #492964
-
-	for mod in ${VMWARE_MODULE_LIST}; do
-		MODULE_NAMES="${MODULE_NAMES} ${mod}(misc:${S}/${mod}-only)"
-	done
 }
 
 src_prepare() {
@@ -77,8 +69,16 @@ src_prepare() {
 	default
 }
 
+src_compile() {
+	for mod in ${VMWARE_MODULE_LIST}; do
+		local modlist+=( ${mod}=misc:${S}/${mod}-only )
+	done
+
+	linux-mod-r1_src_compile
+}
+
 src_install() {
-	linux-mod_src_install
+	linux-mod-r1_src_install
 	local udevrules="${T}/60-vmware.rules"
 	cat > "${udevrules}" <<-EOF
 		KERNEL=="vmci",  GROUP="vmware", MODE="660"
@@ -106,12 +106,12 @@ src_install() {
 }
 
 pkg_postinst() {
-	linux-mod_pkg_postinst
+	linux-mod-r1_pkg_postinst
 	udev_reload
 	ewarn "Don't forget to run '/etc/init.d/vmware restart' to use the new kernel modules."
 }
 
 pkg_postrm() {
-	linux-mod_pkg_postrm
+	linux-mod-r1_pkg_postrm
 	udev_reload
 }

--- a/app-emulation/vmware-modules/vmware-modules-17.5.0-r3.ebuild
+++ b/app-emulation/vmware-modules/vmware-modules-17.5.0-r3.ebuild
@@ -27,6 +27,10 @@ KEYWORDS="~amd64"
 
 RESTRICT="mirror"
 
+RDEPEND="
+	acct-group/vmware
+"
+
 S="${WORKDIR}/vmware-host-modules-${MY_COMMIT}"
 
 pkg_setup() {


### PR DESCRIPTION
When updating to EAPI 8 I had to remove user.eclass from the includes, though I'm not actually sure what exactly it does since the only function from it that's used is enewgroup (and it doesn't seem to have actually created a group after installing?)

The main reason I made the pr is that there seems to be issues getting linux-mod.eclass (r0) to work with clang on a clang compiled kernel, I'm not quite sure why but updating to linux-mod-r1.eclass fixes the issue for me.